### PR TITLE
Austrian VAT numbers consist of 8 digits, not 9

### DIFF
--- a/VIES/ViewModel/ValidationViewModel.swift
+++ b/VIES/ViewModel/ValidationViewModel.swift
@@ -37,7 +37,7 @@ class ValidationViewModel: ObservableObject {
         
         switch selectedCountryIndex {
         case 0:
-            if baseRule || numberVAT.first != "U"  || numberVAT.count != 9 {
+            if baseRule || numberVAT.first != "U"  || numberVAT.count != 8 {
                 return true
             } else {
                 return false


### PR DESCRIPTION
Example: U76905958